### PR TITLE
Fix: Pass 'isAllDay' prop to header event components

### DIFF
--- a/src/EventCell.js
+++ b/src/EventCell.js
@@ -11,6 +11,7 @@ let propTypes = {
   slotEnd: PropTypes.instanceOf(Date),
 
   selected: PropTypes.bool,
+  isAllDay: PropTypes.bool,
   eventPropGetter: PropTypes.func,
   titleAccessor: accessor,
   allDayAccessor: accessor,
@@ -29,6 +30,7 @@ class EventCell extends React.Component {
         className
       , event
       , selected
+      , isAllDay
       , eventPropGetter
       , startAccessor, endAccessor, titleAccessor
       , slotStart
@@ -42,7 +44,7 @@ class EventCell extends React.Component {
     let title = get(event, titleAccessor)
       , end = get(event, endAccessor)
       , start = get(event, startAccessor)
-      , isAllDay = get(event, props.allDayAccessor)
+      , isAllDayEvent = isAllDay || get(event, props.allDayAccessor) || dates.diff(start, dates.ceil(end, 'day'), 'day') > 1
       , continuesPrior = dates.lt(start, slotStart, 'day')
       , continuesAfter = dates.gte(end, slotEnd, 'day')
 
@@ -55,7 +57,7 @@ class EventCell extends React.Component {
           style={{...props.style, ...style}}
           className={cn('rbc-event', className, xClassName, {
             'rbc-selected': selected,
-            'rbc-event-allday': isAllDay || dates.diff(start, dates.ceil(end, 'day'), 'day') > 1,
+            'rbc-event-allday': isAllDayEvent,
             'rbc-event-continues-prior': continuesPrior,
             'rbc-event-continues-after': continuesAfter
           })}
@@ -64,7 +66,7 @@ class EventCell extends React.Component {
         >
           <div className='rbc-event-content' title={title}>
             { Event
-              ? <Event event={event} title={title}/>
+              ? <Event event={event} title={title} isAllDay={isAllDayEvent}/>
               : title
             }
           </div>

--- a/src/EventRowMixin.js
+++ b/src/EventRowMixin.js
@@ -15,6 +15,7 @@ export default {
     start: PropTypes.instanceOf(Date),
 
     selected: PropTypes.object,
+    isAllDay: PropTypes.bool,
     eventPropGetter: PropTypes.func,
     titleAccessor: accessor,
     allDayAccessor: accessor,
@@ -35,7 +36,7 @@ export default {
 
   renderEvent(props, event) {
     let {
-        eventPropGetter, selected, start, end
+        eventPropGetter, selected, isAllDay, start, end
       , startAccessor, endAccessor, titleAccessor
       , allDayAccessor, eventComponent
       , eventWrapperComponent
@@ -50,6 +51,7 @@ export default {
         onSelect={onSelect}
         onDoubleClick={onDoubleClick}
         selected={isSelected(event, selected)}
+        isAllDay={isAllDay}
         startAccessor={startAccessor}
         endAccessor={endAccessor}
         titleAccessor={titleAccessor}

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -280,6 +280,7 @@ export default class TimeGrid extends Component {
             allDayAccessor={this.props.allDayAccessor}
             eventPropGetter={this.props.eventPropGetter}
             selected={this.props.selected}
+            isAllDay={true}
             onSelect={this.handleSelectEvent}
             onDoubleClick={this.handleDoubleClickEvent}
             longPressThreshold={this.props.longPressThreshold}

--- a/src/addons/dragAndDrop/ResizableEvent.js
+++ b/src/addons/dragAndDrop/ResizableEvent.js
@@ -38,7 +38,7 @@ class ResizableEvent extends React.Component {
         )
       })
 
-    return event.allDay ? (
+    return event.allDay || this.props.isAllDay ? (
       <div className='rbc-addons-dnd-resizable-month-event'>
         {Left}
         {title}
@@ -64,6 +64,7 @@ ResizableEvent.propTypes = {
   connectTopDragSource: PropTypes.func,
   event: PropTypes.object,
   title: PropTypes.string,
+  isAllDay: PropTypes.bool,
 }
 
 const eventSourceTop = {


### PR DESCRIPTION
Event components have 2 modes - all-day (can be dragged horizontally only) and non-all-day (dragged only vertically). This mode is detected inside `<EventCell>`. Event has all-day type if:
* event object has property `allDay: true`
* duration of the event is more than 1 day
* prop `isAllDay` is `true` (**This one was added in the PR**)

We have to make all events in header of week and day calendar to be all-day by force. That's why we pass `isAllDay: true` prop down from TimeGrid > DateContentRow > EventRow > EventCell > ResizeableEvent

`<ResizeableEvent>` with `isAllDay: true` prop has exactly the same behavior as `<ResizableMonthEvent>`, that's why I think `<ResizableMonthEvent>` is unnececcary and `<ResizeableEvent>` should be fully adaptive.